### PR TITLE
Added PHPDoc comments to Parser

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -1,7 +1,17 @@
 <?php namespace Rtablada\LiteratePhp;
 
+/**
+ * This Parser can be used to parse Markdown syntax that contains blocks of PHP
+ * code
+ */
 class Parser
 {
+    /**
+     * Parses a string in Markdown syntax and returns PHP code
+     * 
+     * @param string $string
+     * @return string
+     */
 	public function parse($string)
 	{
 		$string = $this->breakParts($string);
@@ -9,11 +19,30 @@ class Parser
 		return "<?php\n\n".$string;
 	}
 
+    /**
+     * Removes lists that are created via Markdown * (star) syntax from a string
+     * of Markdown.
+     * 
+     * Useful because in PHP comments, each line of a multi-line
+     * comment begins with a star. To keep your Markdown lists intact within the
+     * comments, you can use the - (minus) symbol instead of the star within
+     * your Markdown code.
+     * 
+     * @param type $string
+     * @return type
+     */
 	public function removeLists($string)
 	{
 		return preg_replace('/[\n]*\t*\*.*/', '', $string);
 	}
 
+    /**
+     * Breaks a string in Markdown syntax into parts. Every other part is PHP
+     * code, the rest is Markdown and will be turned into PHP comments
+     * 
+     * @param string $string
+     * @return string
+     */
 	public function breakParts($string)
 	{
 		$parts = preg_split('/[\n]+(```|~~~).*[\n]/', $string);
@@ -37,6 +66,13 @@ class Parser
 	}
 
 
+    /**
+     * Parses a string of Markdown and returns a PHP comment block containing
+     * its text
+     * 
+     * @param string $string
+     * @return string
+     */
 	public function parseComments($string)
 	{
 		$return = '';
@@ -62,6 +98,13 @@ class Parser
 		return $return;
 	}
 
+    /**
+     * Parses a block of PHP code (inside a Markdown string), e. g. removes
+     * the leading <?php (if any)
+     * 
+     * @param string $string
+     * @return string
+     */
 	public function parseCode($string)
 	{
 		$string = preg_replace('/<\?php\s/', '', $string);

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -28,8 +28,8 @@ class Parser
      * comments, you can use the - (minus) symbol instead of the star within
      * your Markdown code.
      * 
-     * @param type $string
-     * @return type
+     * @param string $string
+     * @return string
      */
 	public function removeLists($string)
 	{


### PR DESCRIPTION
Hi there,

I've stumbled upon your LiteratePhp parser which is **very** helpful for something I'm currently trying to achieve. :)

I'd like to contribute to the Parser and offer a few small improvements (starting with documenting the code with PHPDoc to make it easier to use in an IDE and easier to understand in general).

However I haven't found a CONTRIBUTING-document nor a README, I hope you even accept pull requests. I also haven't found a LICENSE file but I guess the MIT mention in composer.json is fine. As far as I can tell you probably consider this project a tiny experiment with literate php, however I think it could be much more. If you are interested, I am willing to help. If not, that's ok, too, of course.

The changes below should be self-explanatory.
I have just noticed however that we use different identation styles. If that is a problem for you, I could change my patch.

Yours,
Benedict
